### PR TITLE
fix: do not reset all network settings to default

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -23,13 +23,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/truenas/api_client_golang/truenas_api"
 	"log"
 	"os"
 	"reflect"
 	"strings"
 	"time"
 	"tnascert-deploy/config"
+
+	"github.com/truenas/api_client_golang/truenas_api"
 )
 
 type AppConfigResponse struct {
@@ -97,11 +98,8 @@ func addAsAppCertificate(client Client, cfg *config.Config) error {
 		}
 		if len(response.Result.IxCertificates) != 0 {
 			var params []interface{}
-			m := map[string]map[string]int64{
-				"network": {
-					"certificate_id": ID,
-				},
-			}
+			m := response.Result.Network
+			m["certificate_id"] = ID
 			n := map[string]interface{}{
 				"values": m,
 			}


### PR DESCRIPTION
Hi! First of all, thanks for creating this great tool 😃 I recently migrated from deploy-freenas after the latest TrueNAS Scale updates and noticed this tool mentioned in its README. The automatic upload of app certificates has made the whole certificate process fully automated for me - much appreciated.

I did run into an issue with the upload of app certificates though. In my setup, I deploy the same app (MinIO) twice, with the second instance using different ports to avoid conflicts. When I ran the script, it failed to reload the second instance, reporting that the port was already in use by the first one. On inspection, I found that the customized port settings had been reset to the app's defaults.

After some testing with the WebSocket API, I discovered that including only *.values.network.certificate_id* in the payload seems to trigger a full reset of the Network configuration to default values. It appears TrueNAS merges the incomplete payload with the app’s default configuration during an update.

Further testing showed that including the entire *.values.network* object in the payload prevents unintended overwrites. Interestingly, other parts of the configuration - like Storage - were not reset, so the merge logic seems to avoid modifying sections that aren't included in the payload at all.

With that in mind, I made a minimal change to ensure the full Network object is sent in the update payload. This avoids unexpected resets while still not taking any risks with destroying existing configs by sending too much in the changes payload.