### PR TITLE
Readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@
 
   The tool may be utilized as part of an ACME, Automated Certificate 
   Management Environment to deploy new or renewal certficates to TrueNAS 
-  systems.  The command line usage is as follows:
+  systems, see the **sample-scripts** directory for examples.  The command line 
+  usage is as follows:
 
   ```
   Usage: tnascert-deploy [-hv] [-c value] config_section ... config_section`
@@ -201,6 +202,11 @@ are supported using the RESTful v2.0 API.
 + [TrueNAS api_client_golang](https://github.com/truenas/api_client_golang)
 + [TrueNAS websocket API documentaion](https://www.truenas.com/docs/api/scale_websocket_api.html)
 
+### Sponsor
+
+If you find this tool useful, consider buying me a cup of coffee or
+sponsoring me by hitting the ***Sponsor*** button at the top of this
+page..  
 ### Contact
 + John J. Rushford
 + jrushford@apache.org

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@
 
 ####  Getting Started
 
+  NOTE: If your NAS is currently running with a self-signed or expired
+  certificate, please set the ***tls_skip_verify = true*** setting to avoid
+  connection TLS veification errors.
+
   Precompiled releases of 'tnascert-deploy' are available for FreeBSD, Debian
   Linux, MacOS, or Windows 11.  See the Releases section of this repository.
   The current Release is 2.0.

--- a/clients/helpers.go
+++ b/clients/helpers.go
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package clients
 
 import (

--- a/clients/wsapi/wsapi.go
+++ b/clients/wsapi/wsapi.go
@@ -112,15 +112,21 @@ func (c TrueNASWebSocket) Login() error {
 }
 
 func NewClient(cfg *config.Config) (clients.Client, error) {
+	var verifySSL bool
+	if cfg.TlsSkipVerify == true {
+		verifySSL = false
+	} else {
+		verifySSL = true
+	}
 	serverURL := strings.TrimRight(cfg.ServerURL(), "/") + EndPoint
-	cl, err := truenas_api.NewClient(serverURL, cfg.TlsSkipVerify)
+	cl, err := truenas_api.NewClient(serverURL, verifySSL)
 	if err != nil {
 		return nil, fmt.Errorf("error: %v", err)
 	}
 
 	websocket_client := TrueNASWebSocket{
 		Url:       serverURL,
-		VerifySSL: cfg.TlsSkipVerify,
+		VerifySSL: verifySSL,
 		WSClient:  cl,
 		Cfg:       cfg,
 	}

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 // application release
-const release = "2.0"
+const release = "2.1"
 
 func NewClient(cfg *config.Config) (clients.Client, error) {
 	if cfg.ClientApi == "restapi" {

--- a/main.go
+++ b/main.go
@@ -31,9 +31,9 @@ func NewClient(cfg *config.Config) (clients.Client, error) {
 }
 
 func main() {
-	configFile := getopt.StringLong("config", 'c', config.Config_file, "full path to the configuration file")
 	help := getopt.BoolLong("help", 'h', "print usage information and exit")
 	version := getopt.BoolLong("version", 'v', "print version information and exit")
+	configFile := getopt.StringLong("config", 'c', config.Config_file, "full path to the configuration file")
 	getopt.SetParameters("config_section ... config_section")
 
 	getopt.Parse()

--- a/main.go
+++ b/main.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2025 by John J. Rushford jrushford@apache.org
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package main
 
 import (

--- a/sample-scripts/README.md
+++ b/sample-scripts/README.md
@@ -1,0 +1,28 @@
+
+#### Sample Deployment scripts
+
+The following is a sample **tnas-cert.ini** configuration file showing
+two TrueNAS entries.  One entry is for the newer TrueNAS-SCALE version 25+
+using the websocket API, wsapi.  The 2nd entry is a sample for the older
+TrueNAS core or TrueNAS-SCALE version 24 using the restapi.
+
+Choose the appropriate configuration for your TrueNAS version and then
+edit and add an api_key, connect_host, private_key_path, and 
+full_chain_path to suit your environment. See the Documentation at the
+main repository page for configuration file details.
+
+The sample **deploy-hook.sh** script assumes that you install the 
+configuration file to /usr/local/etc/tnas-cert.ini and that the 
+**tnascert-deploy** executable binary is installed at /usr/local/bin.
+Modify the script for your needs.  The script is pretty basic but should
+work fine.
+
+I use the [certbot](https://certbot.eff.org) ACME client on my FreeBSD webserver 
+to manage and update my **letsencrypt** certificate.  FreeBSD has a 
+port for **certbot** that may be installed using the **pkg** command.  
+
+Once the **certbot** client has been configured to work with your DNS 
+provider and CA, Use the **deploy-hook.sh** script in the certbot 
+**renewal-hooks/deploy** directory.  From then on, your TrueNAS is 
+automatically updated when a new certificate is received.
+

--- a/sample-scripts/deploy-hook.sh
+++ b/sample-scripts/deploy-hook.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Install the configuration file at /usr/local/etc
+# Install tnascert-deploy at /usr/local/bin
+CONFIG=/usr/local/etc/tnas-cert.ini
+COMMAND=/usr/local/bin/tnascert-deploy
+
+# change the name to my-rest-nas if using TrueNAS core or SCALE 24
+if [ -f $CONFIG ] && [ -x $COMMAND ]; then
+  $COMMAND -c $CONFIG my-websocket-nas
+else
+  echo "cannot find a configuration file or the tnascert-deploy command"
+fi
+

--- a/sample-scripts/tnas-cert.ini
+++ b/sample-scripts/tnas-cert.ini
@@ -1,0 +1,35 @@
+# TrueNAS version 25+ websocket sample config
+[my-websocket-nas]
+api_key = (ADD-YOUR-API-KEY-HERE)
+client_api = wsapi
+cert_basename = letsencrypt
+private_key_path = (Add the full path name to your private_key.pem)
+full_chain_path = (Add the full path to your fullchain.pem)
+connect_host = (Add the FQDN or IP address to your NAS)
+protocol = wss
+port = 443
+tls_skip_verify = true
+delete_old_certs = true
+add_as_ui_certificate = true
+add_as_ftp_certificate = false
+add_as_app_certificate = false
+timeoutSeconds = 10
+debug = false
+
+# TrueNAS Core or TruwNAS-SCALE version 24 sample config
+[my-rest-nas]]
+api_key = (Add your API key)
+client_api = restapi
+cert_basename = letsencrypt
+private_key_path = (Add the full path name to your private_key.pem)
+full_chain_path = (Add the full path name to your fullchain.pem)
+connect_host = (Add the FQDN or IP address to your NAS
+protocol = https
+port = 443
+tls_skip_verify = true
+delete_old_certs = true
+add_as_ui_certificate = true
+add_as_ftp_certificate = false
+add_as_app_certificate = false
+timeoutSeconds = 10
+debug = false


### PR DESCRIPTION
Adds a note about using tls_skip_verify when a NAS is currently running with a self-signed or expired certificate